### PR TITLE
fix: update deploy workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: Jekyll Test Build
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache gems
+        uses: actions/cache@v1
+        with:
+          path: vendor/gems
+          key: ${{ runner.os }}-build-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        run: npm install
+      - name: Build
+        run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
       - name: Install dependencies
         run: npm install
       - name: Build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
       - name: Install dependencies
         run: npm install
       - name: Build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-      - name: Build & Deploy to GitHub Pages
-        uses: DavidS/jekyll-deploy@master
+      - name: Install dependencies
+        run: npm install
+      - name: Build
+        run: npm run build
+      - name: Push to gh-pages
+        uses: crazy-max/ghaction-github-pages@v1.3.0
+        with:
+          build_dir: build
+          keep_history: true
         env:
-          JEKYLL_ENV: production
-          GH_PAGES_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
#### What is the goal of this change?
Try to fix the deploy workflow on GitHub Actions. I've updated the deploy workflow to build the project using the npm scripts instead of building with a jekyll dedicated step. Also added a new "test" workflow to check if the build will conclude when creating new PRs.

#### Is there any issue related?
The deploy workflow is broken since a long time, probably due to some jekyll plugins I'm using to paginate the collections.

#### How does the changes address the issue?
Using the npm scripts instead of the jekyll dedicated step may solve the problem, since the runner will use the npm as a middleman before the jekyll.